### PR TITLE
feat(wrapper): Add module timeout and robust process IO

### DIFF
--- a/src/main/java/org/nqm/command/GitCommand.java
+++ b/src/main/java/org/nqm/command/GitCommand.java
@@ -306,9 +306,9 @@ public class GitCommand {
 
   private boolean isConfirmed(String question) throws IOException {
     StdOutUtils.print(question + " ");
-    try (var reader = new BufferedReader(new InputStreamReader(System.in))) {
-      return CONFIRM_YES.matcher(reader.readLine()).matches();
-    }
+    var reader = new BufferedReader(new InputStreamReader(System.in));
+    var line = reader.readLine();
+    return line != null && CONFIRM_YES.matcher(line).matches();
   }
 
   private String[] shouldForcePush(boolean isForce) {

--- a/src/main/java/org/nqm/command/Wrapper.java
+++ b/src/main/java/org/nqm/command/Wrapper.java
@@ -1,21 +1,6 @@
 package org.nqm.command;
 
 import static org.nqm.config.GisConfig.currentDir;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Optional;
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.function.Consumer;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 import org.nqm.GisException;
 import org.nqm.config.GisConfig;
 import org.nqm.config.GisLog;
@@ -23,6 +8,23 @@ import org.nqm.model.GisProcessDto;
 import org.nqm.utils.GisProcessUtils;
 import org.nqm.utils.GisStringUtils;
 import org.nqm.utils.StdOutUtils;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Optional;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
 
 public final class Wrapper {
 
@@ -85,7 +87,51 @@ public final class Wrapper {
 
   public static Queue<String> forEachModuleWith(Predicate<Path> pred, String... args) throws IOException {
     var output = new ConcurrentLinkedQueue<String>();
-    consumeAllModules(pred, exe -> path -> exe.submit(() -> output.add(CommandVerticle.execute(path, args))));
+    var futures = new ArrayList<Future<?>>();
+    var gitModulesFilePath = getFileMarker();
+    var currentDir = currentDir();
+    try (var exe = Executors.newVirtualThreadPerTaskExecutor()) {
+      Optional.of(Path.of(currentDir)).filter(pred).ifPresent(path ->
+          futures.add(exe.submit(() -> output.add(CommandVerticle.execute(path, args)))));
+
+      Files.readAllLines(gitModulesFilePath.toPath()).stream()
+          .map(String::trim)
+          .filter(s -> s.startsWith("path"))
+          .map(s -> s.replace("path = ", ""))
+          .map(dir -> Path.of(currentDir, dir))
+          .filter(dir -> {
+            if (dir.toFile().exists()) {
+              return true;
+            }
+            StdOutUtils.errln("directory '%s' does not exist, will be ignored!".formatted("" + dir));
+            return false;
+          })
+          .filter(pred)
+          .forEach(path -> futures.add(exe.submit(() -> output.add(CommandVerticle.execute(path, args)))));
+
+      // Wait for all futures with configured timeout
+      long timeoutSeconds = org.nqm.config.GisConfig.getModuleTimeoutSeconds();
+      long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(timeoutSeconds);
+      for (Future<?> f : futures) {
+        long remaining = deadline - System.nanoTime();
+        if (remaining <= 0) {
+          GisLog.debug("module execution timeout reached");
+          break;
+        }
+        try {
+          f.get(remaining, TimeUnit.NANOSECONDS);
+        } catch (java.util.concurrent.TimeoutException te) {
+          GisLog.debug("a module task timed out");
+        } catch (InterruptedException ie) {
+          GisLog.debug(ie);
+          Thread.currentThread().interrupt();
+          break;
+        } catch (ExecutionException ee) {
+          GisLog.debug(ee);
+          // continue other modules (errors are aggregated via logs and outputs)
+        }
+      }
+    }
     return output;
   }
 
@@ -135,7 +181,13 @@ public final class Wrapper {
     GisProcessDto result;
     try {
       result = GisProcessUtils.quickRun(path.toFile(), GisConfig.GIT_HOME_DIR, "branch", "--show-current");
-    } catch (IOException e) {
+    }
+    catch (InterruptedException e) {
+      GisLog.debug(e);
+      Thread.currentThread().interrupt();
+      throw new GisException(e.getMessage());
+    }
+    catch (IOException e) {
       GisLog.debug(e);
       throw new GisException(e.getMessage());
     }

--- a/src/main/java/org/nqm/config/GisConfig.java
+++ b/src/main/java/org/nqm/config/GisConfig.java
@@ -38,6 +38,21 @@ public class GisConfig {
   private static final String CURRENT_DIR = "" + Path.of("").toAbsolutePath();
   public static final String GIT_HOME_DIR = "/usr/bin/git";
 
+  private static final String MODULE_TIMEOUT_KEY = "module_timeout_seconds";
+  private static final int MODULE_TIMEOUT_DEFAULT = 60;
+
+  public static int getModuleTimeoutSeconds() {
+    try {
+      var val = props.getProperty(MODULE_TIMEOUT_KEY);
+      if (val == null || val.isBlank()) {
+        return MODULE_TIMEOUT_DEFAULT;
+      }
+      return Integer.parseInt(val.trim());
+    } catch (Exception e) {
+      return MODULE_TIMEOUT_DEFAULT;
+    }
+  }
+
   private static Function<String, String[]> splitValue = val -> val.split(",");
 
   public static String[] getDefaultBranches() {

--- a/src/main/java/org/nqm/utils/GisProcessUtils.java
+++ b/src/main/java/org/nqm/utils/GisProcessUtils.java
@@ -3,6 +3,8 @@ package org.nqm.utils;
 import static org.nqm.utils.StdOutUtils.warnln;
 import java.io.File;
 import java.io.IOException;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import org.nqm.config.GisLog;
 import org.nqm.model.GisProcessDto;
 
@@ -33,19 +35,78 @@ public class GisProcessUtils {
       StdOutUtils.println(String.join(" ", commands));
       return GisProcessDto.EMPTY;
     }
-    var p = new ProcessBuilder(commands).directory(directory).start();
+    var pb = new ProcessBuilder(commands).directory(directory);
+    var p = pb.start();
+
+    var outBaos = new ByteArrayOutputStream();
+    var errBaos = new ByteArrayOutputStream();
+
+    var tOut = Thread.ofVirtual().start(() -> {
+      try (var is = p.getInputStream()) {
+        is.transferTo(outBaos);
+      } catch (IOException e) {
+        GisLog.debug(e);
+      }
+    });
+
+    var tErr = Thread.ofVirtual().start(() -> {
+      try (var es = p.getErrorStream()) {
+        es.transferTo(errBaos);
+      } catch (IOException e) {
+        GisLog.debug(e);
+      }
+    });
+
     var exitCode = p.waitFor();
+    tOut.join();
+    tErr.join();
+
     debugLogIfExitCodeNotZero(exitCode, directory);
-    return new GisProcessDto(new String(p.getInputStream().readAllBytes()), exitCode);
+    var stdout = outBaos.toString(StandardCharsets.UTF_8);
+    var stderr = errBaos.toString(StandardCharsets.UTF_8);
+    if (GisStringUtils.isNotBlank(stderr)) {
+      GisLog.debug(stderr);
+    }
+    return new GisProcessDto(stdout, exitCode);
   }
 
-  public static GisProcessDto quickRun(File directory, String... commands) throws IOException {
+  public static GisProcessDto quickRun(File directory, String... commands) throws IOException, InterruptedException {
     if (dryRunEnabled) {
       StdOutUtils.println(String.join(" ", commands));
       return GisProcessDto.EMPTY;
     }
-    var inputStream = new ProcessBuilder(commands).directory(directory).start().getInputStream();
-    return new GisProcessDto(new String(inputStream.readAllBytes()), 0);
+    var pb = new ProcessBuilder(commands).directory(directory);
+    var p = pb.start();
+
+    var outBaos = new ByteArrayOutputStream();
+    var errBaos = new ByteArrayOutputStream();
+
+    var tOut = Thread.ofVirtual().start(() -> {
+      try (var is = p.getInputStream()) {
+        is.transferTo(outBaos);
+      } catch (IOException e) {
+        GisLog.debug(e);
+      }
+    });
+
+    var tErr = Thread.ofVirtual().start(() -> {
+      try (var es = p.getErrorStream()) {
+        es.transferTo(errBaos);
+      } catch (IOException e) {
+        GisLog.debug(e);
+      }
+    });
+
+    var exitCode = p.waitFor();
+    tOut.join();
+    tErr.join();
+
+    var stdout = outBaos.toString(StandardCharsets.UTF_8);
+    var stderr = errBaos.toString(StandardCharsets.UTF_8);
+    if (GisStringUtils.isNotBlank(stderr)) {
+      GisLog.debug(stderr);
+    }
+    return new GisProcessDto(stdout, exitCode);
   }
 
   public static void spawn(File directory, String... commands) throws IOException {

--- a/src/test/java/org/nqm/utils/GisProcessUtilsTest.java
+++ b/src/test/java/org/nqm/utils/GisProcessUtilsTest.java
@@ -32,7 +32,7 @@ class GisProcessUtilsTest {
   }
 
   @Test
-  void quickRun_OK() throws IOException {
+  void quickRun_OK() throws IOException, InterruptedException {
     // when:
     var result = GisProcessUtils.quickRun(tempPath.toFile(), "pwd");
 


### PR DESCRIPTION
Use a virtual-thread executor to run module commands, collect futures and wait with a configurable timeout (module_timeout_seconds, default 60s). Improve error/interrupt handling in Wrapper and avoid closing System.in in the prompt.

Improve GisProcessUtils to drain stdout/stderr on background threads, log stderr, and return captured stdout; methods now propagate InterruptedException. Update tests accordingly.